### PR TITLE
FACT-2892 update dockerfile to use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,7 @@ FROM hmctsprod.azurecr.io/base/java:21-distroless
 COPY lib/applicationinsights.json /opt/app/
 COPY build/libs/fact-cron-trigger.jar /opt/app/
 
+USER 65532:65532
+
 EXPOSE 8050
 CMD [ "fact-cron-trigger.jar" ]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-2892

### Change description ###

The default dockerfiles run as root, we need to update this to ensure they aren't as the apps shouldn't be running as the root user.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
